### PR TITLE
Fix homebrew install url

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -5,7 +5,7 @@ which brew
 RETSTATUS=$?
 if [ $RETSTATUS -ne 0 ]
 then
-  ruby -e "$(curl -fsSL https://raw.github.com/Homebrew/homebrew/go/install)"
+  ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
   brew update
 else
   tput setaf 1 && tput smul


### PR DESCRIPTION
I encountered this error when I ran this command.

```
ruby -e "$(curl -fsSL https://raw.github.com/Homebrew/homebrew/go/install)"
```

```
Whoops, the Homebrew installer has moved! Please instead run:

ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"

Also, please ask wherever you got this link from to update it to the above.
```

So I fixed the url.
